### PR TITLE
Attribute mine explosions to the detonator zombie instead of the scientist.

### DIFF
--- a/src/game/server/entities/mine.h
+++ b/src/game/server/entities/mine.h
@@ -25,7 +25,7 @@ public:
 	void Tick();
 
 	int GetOwner() const;
-	void Explode();
+	void Explode(int DetonatedBy);
 
 private:
 	int m_IDs[NUM_IDS];


### PR DESCRIPTION
The effect is that when a scientist is killed by its own mine, give points to the zombie who detonated the mine.