### PR TITLE
Add hammering delay to make life harder

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -549,7 +549,7 @@ int CServer::Init()
 		
 /* INFECTION MODIFICATION START ***************************************/
 	SetFireDelay(INFWEAPON_NONE, 0);
-	SetFireDelay(INFWEAPON_HAMMER, 125);
+	SetFireDelay(INFWEAPON_HAMMER, 250);
 	SetFireDelay(INFWEAPON_GUN, 125);
 	SetFireDelay(INFWEAPON_SHOTGUN, 500);
 	SetFireDelay(INFWEAPON_GRENADE, 500);


### PR DESCRIPTION
Hammering often makes zombies stronger. This patch increases limit on
hammering to make zombies target humans instead of hammering all the
time.